### PR TITLE
osx-x86_64/pom.xml: fix sourceFile

### DIFF
--- a/osx-x86_64/pom.xml
+++ b/osx-x86_64/pom.xml
@@ -75,7 +75,7 @@
             <configuration>
               <fileSets>
                 <fileSet>
-                  <sourceFile>${project.basedir}/../secp256k1/.libs/libsecp256k1.so</sourceFile>
+                  <sourceFile>${project.basedir}/../secp256k1/.libs/libsecp256k1.dylib</sourceFile>
                   <destinationFile>${project.basedir}/target/native/coop/rchain/${project.artifactId}.dylib</destinationFile>
                 </fileSet>
               </fileSets>


### PR DESCRIPTION
The fact that the source file had the `.so` suffix on macOS was an LMDB-specific quirk.